### PR TITLE
ensure the --user cli opt is treated as a string

### DIFF
--- a/lib/commands/run.coffee
+++ b/lib/commands/run.coffee
@@ -36,7 +36,7 @@ makeCreateOpts = (imageInfo, serviceConfig, servicesMap, options) ->
     'Env': DockerArgs.formatEnvVariables(serviceConfig.env)
     'Labels':
       'io.fabric.galley.primary': 'false'
-    'User': serviceConfig.user
+    'User': "#{serviceConfig.user}"
     'Volumes': DockerArgs.formatVolumes(serviceConfig.volumes)
     'HostConfig':
       'ExtraHosts': ["#{serviceConfig.name}:127.0.0.1"]


### PR DESCRIPTION
it's possible the user may want to pass a uid instead of a username, in this case the json that is sent to the docker daemon needs to contain a string value rather than a number to marshal into a valid Go struct